### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ sensor:
      password: <unifi_controller_password>
      site: <your "site" on controller> (optional, default: 'default')
      verify_ssl: <True/False> (optional, default: 'False')
-     udm: <True/False> (optional, if you have a Unifi Dream Machine use True as the API is different)
+     udm: <True/False> (optional, default: 'False'. If you have a device running UniFiOS such as a Unifi Dream Machine then use 'True' as the API is different.)
 ```
 


### PR DESCRIPTION
Added the default for the udm variable and added clarity around this being for UniFiOS devices too such as the CloudKey Gen2 which can now run this OS.