### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/unifics/manifest.json
+++ b/custom_components/unifics/manifest.json
@@ -3,9 +3,9 @@
   "name": "Unifi Counter Sensor",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifics",
-  "requirements": ["unificontrol@git+https://github.com/nickovs/unificontrol.git@udm-support#egg=unificontrol"],
+  "requirements": ["unificontrol>=0.2.8"],
   "dependencies": [],
   "codeowners": ["@clyra"],
-  "version": "0.1.3"
+  "version": "0.1.3",
   "iot_class": "local_polling"
 }


### PR DESCRIPTION
UnifiControl has been uploaded to pypi properly now, the github one is no longer needed (soon to be unsupported as a method of use).
Missing a comma, too.