### PR TITLE
Rename device_state_attributes

### DIFF
--- a/custom_components/unifics/sensor.py
+++ b/custom_components/unifics/sensor.py
@@ -245,7 +245,7 @@ class UnifiSensor(Entity):
         return self._unit
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes of this device."""
         #attr = {}
         #if self._last_updated is not None:


### PR DESCRIPTION
Changing device_state_attributes to extra_state_attributes as mentioned in the HA documentation https://dev-docs.home-assistant.io/en/master/api/helpers.html
```
property device_state_attributes
Return entity specific state attributes.

This method is deprecated, platform classes should implement extra_state_attributes instead.
```
Will remove/fix the error
`WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.unifics (<class 'custom_components.unifics.sensor.UnifiSensor'>) implements device_state_attributes. Please report it to the custom component author.`